### PR TITLE
Cancel duplicate CI workflows in same PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,10 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ADMIN_USERNAME: admin
   ADMIN_PASSWORD: ChangeTheP@ssw0rd

--- a/.github/workflows/lint-dockerfile.yml
+++ b/.github/workflows/lint-dockerfile.yml
@@ -13,7 +13,11 @@ on:
       - '**/Dockerfile'
   # Allow manually triggering the workflow.
   workflow_dispatch:
-  
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -13,7 +13,11 @@ on:
       - '**.md'
   # Allow manually triggering the workflow.
   workflow_dispatch:
-  
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -16,6 +16,10 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -13,7 +13,11 @@ on:
       - '**.sh'
   # Allow manually triggering the workflow.
   workflow_dispatch:
-  
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/lint-xml.yml
+++ b/.github/workflows/lint-xml.yml
@@ -14,6 +14,10 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Add concurrency groups to all CI workflows so that when a new commit
is pushed to the same branch/PR, any in-progress workflow run is
automatically cancelled. This saves CI resources and reduces queue times.

https://claude.ai/code/session_016zWUG4FPe2LWNqvYu7deBB