### PR TITLE
ci: group dependabot updates and add 3-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,31 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 3
+    groups:
+      composer-all:
+        patterns:
+          - "*"
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 3
+    groups:
+      actions-all:
+        patterns:
+          - "*"
+
   - package-ecosystem: npm
     directory: /e2e
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 3
+    groups:
+      npm-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Group all Dependabot version-update PRs per ecosystem and apply a 3-day cooldown to reduce noise and supply-chain risk.

## Changes

- **`groups`** — added `patterns: ["*"]` to `composer`, `github-actions`, and `npm` so each ecosystem opens at most one PR per update cycle instead of one PR per package.
- **`cooldown: default-days: 3`** — Dependabot now waits 3 days after a package is published before opening a PR, giving the community time to detect and report malicious releases before they land here.

## Label notes

The `github_actions` label will be applied automatically by the labeler (branch prefix `ci/` + changed file `.github/*.yml`).