### PR TITLE
build: implement mise config with precompiled php and aube

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -129,34 +129,28 @@ jobs:
           echo "Verifying OpenMage SOAP API endpoint..."
           docker compose exec -T joomla sh -c 'curl -sf https://store.dev.local/api/soap?wsdl | grep -q "OpenMage" && echo "✓ OpenMage SOAP API WSDL available" || (echo "✗ OpenMage SOAP API WSDL NOT available" && exit 1)'
 
-      # Setup Node.js and pnpm early to avoid permission issues
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      # Setup development tools using mise
+      - name: Setup mise
+        uses: jdx/mise-action@v4
         with:
-          node-version: '24'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable Corepack
-        run: corepack enable pnpm
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Cache pnpm store
+      # Cache Aube store
+      - name: Cache Aube store
         uses: actions/cache@v5
         with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('e2e/pnpm-lock.yaml') }}
+          path: ~/.local/share/aube/store/v1
+          key: ${{ runner.os }}-aube-store-${{ hashFiles('e2e/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-aube-store-
 
       - name: Install E2E dependencies
         working-directory: e2e
-        run: pnpm install
+        run: aube install
 
       - name: Get Playwright version
         working-directory: e2e
-        run: echo "PLAYWRIGHT_VERSION=$(pnpm exec playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(aubx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -170,16 +164,16 @@ jobs:
         run: |
           if [ "${{ steps.playwright-cache.outputs.cache-hit }}" != 'true' ]; then
             echo "Cache miss - Installing browsers with system dependencies..."
-            pnpm exec playwright install --with-deps chromium
+            aubx playwright install --with-deps chromium
           else
             echo "Cache hit - Installing system dependencies only..."
-            pnpm exec playwright install-deps chromium
+            aubx playwright install-deps chromium
           fi
 
       # Run E2E tests
       - name: Run E2E tests
         working-directory: e2e
-        run: pnpm exec playwright test --reporter=html,github
+        run: aubx playwright test --reporter=html,github
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ tmp/
 /magento/var
 .claude/
 .agent/
+
+# mise
+.mise.local.toml
+.mise/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,13 @@
 
 ---
 
+## Environment & Tooling
+
+This repository uses [mise](https://mise.jdx.dev/) to manage development runtimes and CLI versions (PHP, Composer, Node.js, and Aube).
+
+- To install the project's development tools, run: `mise install`
+- Runtimes are configured in [mise.toml](file:///Users/akunzai/code/MageBridgeCore/mise.toml) (using `adwinying/php` for precompiled static PHP binaries).
+
 ## Build & Verify
 
 - `composer bundle` or `./bundle.sh` - Bundle the extension

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -5,14 +5,14 @@ E2E tests use Playwright to test MageBridge in a real browser environment.
 ## Commands
 
 ```bash
-cd e2e && pnpm install
-pnpm test                                        # Run all tests
-pnpm test:ui                                     # Interactive UI mode
-pnpm test:headed                                 # Show browser execution
-pnpm test --project=joomla-admin                 # Run only Joomla admin tests
-pnpm test --project=joomla-site                  # Run only Joomla site tests
-pnpm test --project=openmage-admin               # Run only OpenMage admin tests
-pnpm test -- tests/joomla/admin/config.spec.ts   # Run specific test
+cd e2e && aube install
+aubr test                                        # Run all tests (or: aube run test)
+aubr test:ui                                     # Interactive UI mode
+aubr test:headed                                 # Show browser execution
+aubr test --project=joomla-admin                 # Run only Joomla admin tests
+aubr test --project=joomla-site                  # Run only Joomla site tests
+aubr test --project=openmage-admin               # Run only OpenMage admin tests
+aubr test -- tests/joomla/admin/config.spec.ts   # Run specific test
 ```
 
 ## Joomla 5 Playwright Selectors

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,7 +2,6 @@
   "name": "magebridge-e2e",
   "version": "1.0.0",
   "private": true,
-  "packageManager": "pnpm@11.4.0",
   "description": "E2E tests for MageBridge using Playwright",
   "scripts": {
     "test": "playwright test",

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+"github:adwinying/php" = "8.4"
+"github:composer/composer" = { version = "latest", postinstall = "mv \"$MISE_TOOL_INSTALL_PATH/composer.phar\" \"$MISE_TOOL_INSTALL_PATH/composer\" && chmod +x \"$MISE_TOOL_INSTALL_PATH/composer\"" }
+node = "lts"
+aube = "latest"


### PR DESCRIPTION
This PR adds mise.toml to configure PHP 8.3 (precompiled via adwinying/php), composer (with postinstall auto-rename), Node.js, and Aube package manager.